### PR TITLE
Create ask returns None for trivial rational and integer queries #27670

### DIFF
--- a/ask returns None for trivial rational and integer queries #27670
+++ b/ask returns None for trivial rational and integer queries #27670
@@ -1,0 +1,16 @@
+ask returns None for trivial rational and integer queries #27670
+
+
+REASON:--
+
+The issue arises because of how Python handles floating-point arithmetic. When you write 1/2, or any p/q (where p and q are integers ) python evaluates as 0.5 or solution of p/q when p is divided by q .
+Since ask(Q.rational(x)) works best with symbolic expressions from SymPy rather than floating-point numbers, it returns None because 0.5 is not explicitly represented as a rational number.
+
+how to correct this issue
+
+Use Rational from sympy to explicitly define numbers as rational.
+correct code:-
+from sympy import Q, ask, Rational
+
+print(ask(Q.rational(Rational(1, 2)))) # True
+print(ask(Q.integer(1 / Rational(1, 2)))) # True


### PR DESCRIPTION
error solution

The issue arises because of how Python handles floating-point arithmetic. When you write 1/2, or any p/q (where p and q are integers ) python evaluates as 0.5 or solution of p/q when p is divided by q .
Since ask(Q.rational(x)) works best with symbolic expressions from SymPy rather than floating-point numbers, it returns None because 0.5 is not explicitly represented as a rational number.

how to correct this issue

Use Rational from sympy to explicitly define numbers as rational.
correct code:-
from sympy import Q, ask, Rational

print(ask(Q.rational(Rational(1, 2)))) # True
print(ask(Q.integer(1 / Rational(1, 2)))) # True

